### PR TITLE
Modifying the linting workflows to clear the cache

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,6 +20,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install flake8
+      - name: Clear Flake8 cache
+        run: rm -rf ~/.cache/flake8 || true
       - name: Lint with Flake8
         if: always()
         run: |


### PR DESCRIPTION
The modification is to clear the cache of flake8 in order not to detect out-dated directories.